### PR TITLE
Fix and re-enable the `Add messages to bottom` setting

### DIFF
--- a/src/renderer/pages/Chat.vue
+++ b/src/renderer/pages/Chat.vue
@@ -11,6 +11,7 @@
       </div>
       <div v-else-if="!isLoading && isWaitingForMessages" style="font-size: 12pt">
         <span>Connected, waiting for messages...</span>
+        <div>New messages will be added to the {{ addNewMessageToBottom ? 'bottom' : 'top' }}</div>
       </div>
       <div v-for="item of data" v-else :key="item.key">
         <div
@@ -33,7 +34,7 @@
               {{ (item.user && item.user.name) || 'John Doe' }}
               <span class="text-white font-light">: </span></b
             >
-            <ChatMessage :id="item.key" :message="item.message" @expired="handleRemoveMessage" />
+            <ChatMessage :id="item.key" :message="item.message" />
           </div>
         </div>
       </div>
@@ -80,15 +81,9 @@ export default class Chat extends Vue {
 
   isWaitingForMessages = true;
 
-  // inverted chat set to default
-  // until we figure out why the scrolling isn't working in frameless windows
-  addNewMessageToBottom = false; // !this.$config.get(StoreConstants.ReverseChat, false);
+  addNewMessageToBottom = !this.$config.get(StoreConstants.ReverseChat, false);
 
   interval;
-
-  handleRemoveMessage(id: IMessageResponse): void {
-    this.data.splice(this.data.indexOf(id), 1);
-  }
 
   handleInterval(): void {
     const now = new Date().getTime();
@@ -207,7 +202,18 @@ export default class Chat extends Vue {
   updated(): void {
     const container = this.$el.querySelector('#chat-messages');
     if (container) {
-      container.scrollTop = this.addNewMessageToBottom ? container.scrollHeight : 0;
+      const messages = container.querySelectorAll('#message');
+      const lastMessage = messages && messages[messages.length - 1];
+
+      if (this.addNewMessageToBottom) {
+        // For some reason using `container.scrollTop = ...` does not work correctly
+        // when the window is invisible. This, on the other hand, works correctly.
+        if (lastMessage) {
+          lastMessage.scrollIntoView();
+        }
+      } else {
+        container.scrollTop = 0;
+      }
     }
   }
 }

--- a/src/renderer/pages/Chat.vue
+++ b/src/renderer/pages/Chat.vue
@@ -113,7 +113,7 @@ export default class Chat extends Vue {
   }
 
   addMessage(userstate, message, badges): void {
-    const newItem = {
+    const newItem: IMessageResponse = {
       user: {
         color: userstate.color || '#8d41e6',
         name: userstate.username,


### PR DESCRIPTION
This fixes this scrolling of chat if the setting to reverse chat is disabled.

Previously, this setting was ignored because of the scrolling but that this fixes.

This is a pre-release PR, pending upstream fixes.