### PR TITLE
WIP: Add BetterTTV emotes support

### DIFF
--- a/src/renderer/pages/Chat.vue
+++ b/src/renderer/pages/Chat.vue
@@ -168,6 +168,7 @@ export default class Chat extends Vue {
         throw new Error(`Failed to connect to channel ${this.broadCaster}: ${err}`);
       });
 
+      // Try (and silently fail if needed) to fetch BTTV Global emotes
       await this.message.fetchBTTVEmotes();
 
       this.isLoading = false;

--- a/src/renderer/pages/Chat.vue
+++ b/src/renderer/pages/Chat.vue
@@ -168,6 +168,8 @@ export default class Chat extends Vue {
         throw new Error(`Failed to connect to channel ${this.broadCaster}: ${err}`);
       });
 
+      await this.message.fetchBTTVEmotes();
+
       this.isLoading = false;
 
       // Only show the waiting for messages prompt for a bit
@@ -186,9 +188,9 @@ export default class Chat extends Vue {
         if (userstate.badges !== null) {
           badges = await this.message.getUserBadges(userstate);
         }
-        if (userstate.emotes !== null) {
-          message = await this.message.formatMessage(message, userstate.emotes);
-        }
+
+        message = await this.message.formatMessage(message, userstate);
+
         this.addMessage(userstate, message, badges);
       });
     } else {

--- a/src/utils/Message.ts
+++ b/src/utils/Message.ts
@@ -64,7 +64,7 @@ export default class Message {
       '<img alt="emote" class="emotes align-middle" src="https://cdn.betterttv.net/emote/%BTTVID%/1x" />';
     function escapeRegExp(string) {
       // Directly out of MDN lmao
-      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+      // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
       return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
     }
     const codeToRegex = (code) => new RegExp(`(^|[^\w])${escapeRegExp(code)}([^\w]|$)`, 'g');

--- a/src/utils/Message.ts
+++ b/src/utils/Message.ts
@@ -15,7 +15,7 @@ export default class Message {
     this.channelBadgeList = [];
     this.badgeList = [];
 
-    // "string" => "stringID"
+    // Mappings of the emote code (e.g. ":tf:", "NODDERS", etc) to the ID that can be put into a CDN URL
     this.bttvGlobalEmotes = {};
     this.bttvChannelEmotes = {};
   }

--- a/src/utils/Message.ts
+++ b/src/utils/Message.ts
@@ -17,7 +17,7 @@ export default class Message {
 
     // "string" => "stringID"
     this.bttvGlobalEmotes = {};
-    this.bttvGlobalEmotes = {};
+    this.bttvChannelEmotes = {};
   }
 
   private async fetchFFZEmotes(): Promise<void> {


### PR DESCRIPTION
In this joke I will add BetterTTV support both for global and channel specific emotes.

## TODO before upstream PR

  * [x] Global
  * [x] Channel specific
  * [ ] Add setting to enable/disable
  * [ ] Get the channel ID ahead of first message
    * Looks like I can get the channel id from some of the replies to the join message of the channel.
    
      ![image](https://user-images.githubusercontent.com/40149/163550169-5c6fd0cf-fdf9-43d6-a03e-3f007f3b5cce.png)
